### PR TITLE
Update reference to the asset bundle

### DIFF
--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -1,7 +1,7 @@
 
 {% extends "_layouts/cp" %}
 
-{% do view.registerAssetBundle("hillholliday\\usermanual\\assetbundles\\usermanual\\UserManualAsset") %}
+{% do view.registerAssetBundle("hillholliday\\usermanual\\assetbundles\\UserManual\\UserManualAsset") %}
 
 {% set sectionSelected = (craft.userManual.settings.section is defined)
   ? craft.userManual.settings.section


### PR DESCRIPTION
The casing of the asset bundle include does not match the one [defined in the namespace](https://github.com/hillholliday/Craft-User-Manual/blob/master/src/assetbundles/usermanual/UserManualAsset.php#L14). This corrects an issue where the user might receive a...

> Failed to instantiate component or class "hillholliday\usermanual\assetbundles\usermanual\UserManualAsset".

...when accessing the dashboard.

This is potentially related to #16 