### PR TITLE
Fix UserManualAsset namespace casing

### DIFF
--- a/src/assetbundles/usermanual/UserManualAsset.php
+++ b/src/assetbundles/usermanual/UserManualAsset.php
@@ -11,7 +11,7 @@
  * @copyright Copyright (c) 2018 Rob Erskine
  */
 
-namespace hillholliday\usermanual\assetbundles\UserManual;
+namespace hillholliday\usermanual\assetbundles\usermanual;
 
 use Craft;
 use craft\web\AssetBundle;

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -1,7 +1,7 @@
 
 {% extends "_layouts/cp" %}
 
-{% do view.registerAssetBundle("hillholliday\\usermanual\\assetbundles\\UserManual\\UserManualAsset") %}
+{% do view.registerAssetBundle("hillholliday\\usermanual\\assetbundles\\usermanual\\UserManualAsset") %}
 
 {% set sectionSelected = (craft.userManual.settings.section is defined)
   ? craft.userManual.settings.section


### PR DESCRIPTION
Composer 2 is going to be more strict about class names / namespaces matching the casing of their folders and files.