### PR TITLE
Add hash tag based navigation for large  list of menu items.

### DIFF
--- a/src/assetbundles/usermanual/dist/css/UserManual.css
+++ b/src/assetbundles/usermanual/dist/css/UserManual.css
@@ -175,3 +175,21 @@
 .sidebar nav li ul {
   display: block !important;
 }
+
+
+//  style to mange hash tag links
+#sidebar{
+  max-height: calc(100%) !important;
+  height: auto !important;
+  position: static !important;
+}
+
+#content{
+  position: fixed !important;
+  width: calc(100vw - 570px);
+}
+
+
+.peUserManual #user-manual-menu{
+  margin-top: 185px;
+}

--- a/src/assetbundles/usermanual/dist/css/UserManual.css
+++ b/src/assetbundles/usermanual/dist/css/UserManual.css
@@ -189,4 +189,6 @@
 
 .pe-user-manual #user-manual-menu{
   margin-top: 185px;
+  max-height: calc(100vh - 212px);
+  overflow-y: scroll;
 }

--- a/src/assetbundles/usermanual/dist/css/UserManual.css
+++ b/src/assetbundles/usermanual/dist/css/UserManual.css
@@ -176,8 +176,6 @@
   display: block !important;
 }
 
-
-//  style to mange hash tag links
 #sidebar{
   max-height: calc(100%) !important;
   height: auto !important;
@@ -189,7 +187,6 @@
   width: calc(100vw - 570px);
 }
 
-
-.peUserManual #user-manual-menu{
+.pe-user-manual #user-manual-menu{
   margin-top: 185px;
 }

--- a/src/assetbundles/usermanual/dist/js/UserManual.js
+++ b/src/assetbundles/usermanual/dist/js/UserManual.js
@@ -11,10 +11,9 @@
  */
 
  $('document').ready(function () {
-   //  check if hash tag is availbe and
-   //  get the menu id
+   
    if(window.location.hash.substr(1)){
-     $('body').addClass('peUserManual');
+     $('body').addClass('pe-user-manual');
    }
    else{
      $('#global-header').hide();

--- a/src/assetbundles/usermanual/dist/js/UserManual.js
+++ b/src/assetbundles/usermanual/dist/js/UserManual.js
@@ -9,3 +9,15 @@
  * @package   Usermanual
  * @since     2.0.0
  */
+
+ $('document').ready(function () {
+   //  check if hash tag is availbe and
+   //  get the menu id
+   if(window.location.hash.substr(1)){
+     $('body').addClass('peUserManual');
+   }
+   else{
+     $('#global-header').hide();
+   }
+
+ });

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -9,14 +9,14 @@
 
 {% set title = craft.userManual.name|t %}
 {% set sidebar %}
-  <nav>
+  <nav id="user-manual-menu">
     {% set help = craft.entries.sectionId(sectionSelected).all() %}
     <ul>
       {% nav page in help %}
         {% set active = page.slug == craft.app.request.segments|last or loop.first and craft.app.request.segments|last == 'usermanual' %}
-        <li>
+        <li id="{{ page.id }}">
           <a {% if active %}class="sel"{% endif %}
-            href="{{ url('usermanual/' ~ page.uri) }}">
+            href="{{ url('usermanual/' ~ page.uri) }}#{{ page.id }}">
             {{page.title}}
           </a>
           {% ifchildren %}


### PR DESCRIPTION
When the user manual has a long length of the menu items and after scrolling all the way down, if the user clicked on any help menu item which is bottom the list. The page will be refreshed to the new help section but clicked menu item all the down(out of the viewpoint), there is no clue about where is the clicked item.

This code bit always keeps the clicked menu item on the viewpoint.