### PR TITLE
- Removed the fixed position for the #content

### DIFF
--- a/src/assetbundles/usermanual/dist/css/UserManual.css
+++ b/src/assetbundles/usermanual/dist/css/UserManual.css
@@ -183,7 +183,6 @@
 }
 
 #content{
-  position: fixed !important;
   width: calc(100vw - 570px);
 }
 


### PR DESCRIPTION
PLEASE BEWARE.

I don't know if that CSS property is required, as I don't use the plugin in its original intended way.
In my case, I added the whole manual on a single page, and when the content of this page is too long, you cannot scroll down.