### PR TITLE
Update to use `registerTwigExtension`

### DIFF
--- a/src/UserManual.php
+++ b/src/UserManual.php
@@ -226,6 +226,6 @@ class UserManual extends Plugin
 
     private function _addTwigExtensions()
     {
-        Craft::$app->view->twig->addExtension(new UserManualTwigExtension);
+        Craft::$app->view->registerTwigExtension(new UserManualTwigExtension);
     }
 }


### PR DESCRIPTION
This PR moves to the `registerTwigExtension` method to register the Twig extension, as documented in the 4.x docs: https://craftcms.com/docs/4.x/extend/extending-twig.html#register-a-twig-extension. This fixes the `Twig instantiated before Craft is fully initialized.` warning that the plugin is throwing on each request in Craft 4 installations.

Fixes https://github.com/RobErskine/Craft-User-Manual/issues/32.

## How to test

- Load the plugin with this branch active in a Craft 4 site.
- Visit an admin page and confirm that the `Twig instantiated before Craft is fully initialized.` warning doesn't appear in the web logs.
- Do the same for a frontend page.