### PR TITLE
Use ID instead of slug to query entries for CP entry URLs

### DIFF
--- a/src/UserManual.php
+++ b/src/UserManual.php
@@ -162,16 +162,6 @@ class UserManual extends Plugin
         ]];
         foreach (Craft::$app->sections->getAllSections() as $section) {
             $siteSettings = Craft::$app->sections->getSectionSiteSettings($section['id']);
-            $hasUrls = false;
-            foreach ($siteSettings as $siteSetting) {
-                if ($siteSetting->hasUrls) {
-                    $hasUrls = true;
-                }
-            }
-
-            if (!$hasUrls) {
-                continue;
-            }
             $options[] = [
                 'label' => $section['name'],
                 'value' => $section['id'],

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -15,7 +15,7 @@
       {% set help = craft.entries.sectionId(sectionSelected).all() %}
       <ul>
         {% nav page in help %}
-          {% set active = page.slug == craft.app.request.segments|last or loop.first and craft.app.request.segments|last == 'usermanual' %}
+          {% set active = page.id == craft.app.request.segments|last or loop.first and craft.app.request.segments|last == 'usermanual' %}
           <li id="{{ page.id }}">
             <a {% if active %}class="sel"{% endif %}
               href="{{ url('usermanual/' ~ page.id) }}">

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -18,7 +18,7 @@
           {% set active = page.slug == craft.app.request.segments|last or loop.first and craft.app.request.segments|last == 'usermanual' %}
           <li id="{{ page.id }}">
             <a {% if active %}class="sel"{% endif %}
-              href="{{ url('usermanual/' ~ page.uri) }}#{{ page.id }}">
+              href="{{ url('usermanual/' ~ page.id) }}">
               {{page.title}}
             </a>
             {% ifchildren %}

--- a/src/twigextensions/UserManualTwigExtension.php
+++ b/src/twigextensions/UserManualTwigExtension.php
@@ -74,14 +74,14 @@ class UserManualTwigExtension extends AbstractExtension
         $sectionId = $settings->section;
 
         if (count($segments) === 1 && $segment === 'usermanual') {
-            $slug = null;
+            $id = null;
         } else {
-            $slug = $segment;
+            $id = $segment;
         }
 
         $criteria = [
             'sectionId' => $sectionId,
-            'slug' => $slug,
+            'id' => $id,
         ];
 
         Craft::configure($query, $criteria);


### PR DESCRIPTION
Use IDs instead of slugs in the `index.twig` cp template.
Uses IDs instead of slugs in the last segment of the requested URL to query the entry.

Closes #15 