### PR TITLE
Fix for potential Craft 4 to Craft 5 migration issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft User Manual
 
+## 5.0.1 - 2024-04-30
+ - Required "section" config setting to be an integer. This may be a breaking change if you had the section set in the `config/usermanual.php` file using a string instead of an integer. (This fix is to help address possible issue in Craft 4 to Craft 5 migration.)
+ - Added "enabledSideBar" config setting to enable/disable the sidebar on the manual page.
+
 ## 5.0.0 - 2024-04-04
 - Craft 5 support.
 - Adjusted version number to reflect Craft 5 compatibility.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To install the plugin in your Craft 3 project, follow these instructions.
 5. Click the **User Manual** link in the CP nav.
 ## Configuration
 
-* All settings may be optionally configured using a [config file](http://buildwithcraft.com/docs/plugins/plugin-settings#config-file). The values, contained in [`config.php`](https://github.com/roberskine/Craft-User-Manual/blob/master/src/config.php), are described below:
+* All settings may be optionally configured using a [config file](https://craftcms.com/docs/5.x/extend/plugin-settings.html#overriding-setting-values). The values, contained in [`config.php`](https://github.com/roberskine/Craft-User-Manual/blob/master/src/config.php), are described below:
 
 <a id="config-settings-pluginNameOverride"></a>
 ### pluginNameOverride
@@ -65,7 +65,7 @@ Path is relative to ../craft/templates/.
 
 <a id="config-settings-section"></a>
 ### section
-Entries in this section must have associated urls.
+Entries in this section must have associated urls. When this value is set from the `usermanua.php` file, it much use the section ID as the value, not the section handle.
 
 ### enabledSideBar
 Enables the sidebar on the manual page
@@ -82,7 +82,7 @@ Defaults to true.
 This plugin was inspired by the team over at [70kft](http://70kft.com/) for their work on [Craft-Help](https://github.com/70kft/craft-help). While their plugin is definitely more flexible in terms of writing custom markdown in separate files, we wanted to create something that would make it easier for anyone to edit documentation without making any changes to the server. This works particularly well for larger projects where more than one person (especially non-devs) are writing documentation for how to use the CMS.
 
 ## Releases
-* **5.0.0** - Craft 5 support! Thanks to [John Morton](https://github.com/) and [Dalton Rooney](daltonrooney) for your contributions. 
+* **5.0.0** - Craft 5 support! Thanks to [John Morton](https://github.com/) and [Dalton Rooney](daltonrooney) for your contributions.
 * **4.0.0** - Craft 4 support! Thanks to [Chris DuCharme](https://github.com/Chris-DuCharme) for migrating up to Craft 4.
 * **2.1.0** - Merging PRs from [JorgeAnzola](https://github.com/JorgeAnzola) and [sameerast](https://github.com/sameerast)
 * **2.0.3** - Forcing updating to plugin store

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Defaults to true.
 This plugin was inspired by the team over at [70kft](http://70kft.com/) for their work on [Craft-Help](https://github.com/70kft/craft-help). While their plugin is definitely more flexible in terms of writing custom markdown in separate files, we wanted to create something that would make it easier for anyone to edit documentation without making any changes to the server. This works particularly well for larger projects where more than one person (especially non-devs) are writing documentation for how to use the CMS.
 
 ## Releases
-* **5.0.0** - Craft 5 support! Thanks to [John Morton](https://github.com/) and [Dalton Rooney](daltonrooney) for your contributions.
+* **5.0.1** - Required "section" config setting to be an integer. Added "enabledSideBar" config setting to enable/disable the sidebar on the manual page. This fix is to help address possible issue in Craft 4 to Craft 5 migration.
+* **5.0.0** - Craft 5 support! Thanks to [John Morton](https://github.com/johnfmorton) and [Dalton Rooney](daltonrooney) for your contributions.
 * **4.0.0** - Craft 4 support! Thanks to [Chris DuCharme](https://github.com/Chris-DuCharme) for migrating up to Craft 4.
 * **2.1.0** - Merging PRs from [JorgeAnzola](https://github.com/JorgeAnzola) and [sameerast](https://github.com/sameerast)
 * **2.0.3** - Forcing updating to plugin store

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "hillholliday/craft-user-manual",
     "description": "Craft User Manual allows developers (or even content editors) to provide CMS documentation using Craft's built-in sections (singles, channels, or structures) to create a `User Manual` or `Help` section directly in the control panel.",
     "type": "craft-plugin",
-    "version": "5.0.0",
+    "version": "dev-customization",
     "keywords": [
         "craft",
         "cms",

--- a/src/UserManual.php
+++ b/src/UserManual.php
@@ -189,24 +189,6 @@ class UserManual extends Plugin
             $settings->$settingName = $settingValueOverride ?? $settingValue;
         }
 
-        // Allow handles from config
-        if (!is_numeric($settings->section)) {
-            // Get the Craft CMS version
-        $version = Craft::$app->getVersion();
-
-        // Check the first character to determine the major version
-        $majorVersion = $version[0];
-
-            if ($majorVersion === '4') {
-                $section = Craft::$app->getSections()->getSectionByHandle('homepage');
-            } else {
-                $section = Craft::$app->entries->getSectionByHandle('homepage');
-            }
-            if ($section) {
-                $settings->section = $section->id;
-            }
-        }
-
         return $settings;
     }
 
@@ -276,7 +258,8 @@ class UserManual extends Plugin
     }
 
     // Abstracted method to get site settings based on version
-    private function getSectionSiteSettings($sectionId) {
+    private function getSectionSiteSettings($sectionId): array
+    {
         $majorVersion = $this->getMajorVersion();
 
         if ($majorVersion === '4') {

--- a/src/UserManual.php
+++ b/src/UserManual.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * usermanual plugin for Craft CMS 3.x
+ * usermanual plugin for Craft CMS 4.x / 5.x
  *
  * Craft User Manual allows developers (or even content editors) to provide CMS
  * documentation using Craft's built-in sections (singles, channels, or structures)

--- a/src/UserManual.php
+++ b/src/UserManual.php
@@ -188,6 +188,23 @@ class UserManual extends Plugin
             $settings->$settingName = $settingValueOverride ?? $settingValue;
         }
 
+        // if section is a string, convert to int by looking up the section ID
+        if (($settings !== null) && is_string($settings->section)) {
+            $sections = $this->getSections();
+            foreach ($sections as $section) {
+                if ($section['handle'] === $settings->section) {
+                    $settings->section = $section['id'];
+                }
+            }
+        }
+
+        // if section is still a string, set to null
+        // this will prevent an error when an invalid section is assigned
+        // via a string in the config file
+        if (($settings !== null) && is_string($settings->section)) {
+            $settings->section = null;
+        }
+
         return $settings;
     }
 

--- a/src/UserManual.php
+++ b/src/UserManual.php
@@ -118,8 +118,7 @@ class UserManual extends Plugin
         $pluginNameOverride = $this->getSettings()->pluginNameOverride;
 
         return ($pluginNameOverride)
-            ? $pluginNameOverride
-            : $pluginName;
+            ?: $pluginName;
     }
 
     public function registerCpUrlRules(RegisterUrlRulesEvent $event): void

--- a/src/assetbundles/usermanual/UserManualAsset.php
+++ b/src/assetbundles/usermanual/UserManualAsset.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * usermanual plugin for Craft CMS 4.x
+ * usermanual plugin for Craft CMS 4.x / 5.x
  *
  * Craft User Manual allows developers (or even content editors) to provide CMS
  * documentation using Craft's built-in sections (singles, channels, or structures)

--- a/src/config.php
+++ b/src/config.php
@@ -28,6 +28,6 @@
 return [
     'pluginNameOverride' => null,
     'templateOverride' => null,
-    'section' => null, // section ID (int)
+    'section' => null, // section ID (int) or section handle (string)
     'enabledSideBar' => true,
 ];

--- a/src/config.php
+++ b/src/config.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * usermanual plugin for Craft CMS 4.x
+ * usermanual plugin for Craft CMS 4.x / 5.x
  *
  * Craft User Manual allows developers (or even content editors) to provide CMS
  * documentation using Craft's built-in sections (singles, channels, or structures)

--- a/src/config.php
+++ b/src/config.php
@@ -28,6 +28,6 @@
 return [
     'pluginNameOverride' => null,
     'templateOverride' => null,
-    'section' => null, // section ID (int) or handle (string)
+    'section' => null, // section ID (int)
     'enabledSideBar' => true,
 ];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * usermanual plugin for Craft CMS 4.x / 5.x
+ * usermanual plugin for Craft CMS 3.x
  *
  * Craft User Manual allows developers (or even content editors) to provide CMS
  * documentation using Craft's built-in sections (singles, channels, or structures)
@@ -29,19 +29,19 @@ class Settings extends Model
     // =========================================================================
 
     /**
-     * @var string
+     * @var string | null
      */
-    public string $pluginNameOverride;
+    public ?string $pluginNameOverride = "";
 
     /**
-     * @var string
+     * @var string | null
      */
-    public string $templateOverride;
+    public ?string $templateOverride = "";
 
     /**
-     * @var integer
+     * @var integer | null
      */
-    public int $section;
+    public ?int $section = null;
 
     /**
      * @var boolean

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * usermanual plugin for Craft CMS 3.x
+ * usermanual plugin for Craft CMS 4.x / 5.x
  *
  * Craft User Manual allows developers (or even content editors) to provide CMS
  * documentation using Craft's built-in sections (singles, channels, or structures)

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -39,9 +39,9 @@ class Settings extends Model
     public ?string $templateOverride = "";
 
     /**
-     * @var integer | null
+     * @var int|string|null
      */
-    public ?int $section = null;
+    public int|string|null $section = null;
 
     /**
      * @var boolean
@@ -60,7 +60,12 @@ class Settings extends Model
     {
         return [
             [['pluginNameOverride', 'templateOverride'], 'string'],
-            ['section', 'number'],
+            ['section', function ($attribute): void
+                {
+                    if (!is_int($this->$attribute) && !is_string($this->$attribute)) {
+                        $this->addError($attribute, Craft::t('usermanual', 'config file section error'));
+                    }
+                }],
             ['enabledSideBar', 'boolean']
         ];
     }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * usermanual plugin for Craft CMS 3.x
+ * usermanual plugin for Craft CMS 4.x / 5.x
  *
  * Craft User Manual allows developers (or even content editors) to provide CMS
  * documentation using Craft's built-in sections (singles, channels, or structures)
@@ -31,22 +31,22 @@ class Settings extends Model
     /**
      * @var string
      */
-    public $pluginNameOverride;
+    public string $pluginNameOverride;
 
     /**
      * @var string
      */
-    public $templateOverride;
+    public string $templateOverride;
 
     /**
      * @var integer
      */
-    public $section;
+    public int $section;
 
     /**
      * @var boolean
      */
-    public $enabledSideBar = true;
+    public bool $enabledSideBar = true;
 
 
 

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -65,8 +65,25 @@
 {% endif %}
 
 {% set instructions %}
-For more control over the output, you may optionally override the default template.<br>
-Path is relative to <code>{{ siteTemplatesPath }}</code>.
+The sidebar in the default User Manual template allows for multiple pages to make up the user manual. If you have a single page, that navigation is not needed and can be toggled off.
+{% endset %}
+{% set configOverride = 'enabledSideBar' in overrides %}
+
+{{ forms.lightSwitchField({
+    label: "Enable Sidebar"|t,
+    id: 'enabledSideBar',
+    name: 'enabledSideBar',
+    instructions: instructions|raw,
+    on: settings.enabledSideBar,
+    onLabel: "Yes"|t,
+    offLabel: "No"|t,
+    warning: configOverride ? configWarning('enabledSideBar'),
+    disabled: configOverride,
+    readonly: configOverride,
+})}}
+
+{% set instructions %}
+For more control over the output, you may optionally override the default template. Path is relative to <code>{{ siteTemplatesPath }}</code>.
 {% endset %}
 {% set configOverride = 'templateOverride' in overrides %}
 
@@ -82,3 +99,5 @@ Path is relative to <code>{{ siteTemplatesPath }}</code>.
     disabled: configOverride,
     readonly: configOverride,
 })}}
+
+

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -56,7 +56,7 @@
     readonly: configOverride,
 } %}
 
-{{ configOverride ? forms.textField(opts) : forms.selectField(opts) }}
+{{  forms.selectField(opts)  }}
 {% else %}
 <div class="warning">
   Setup is not complete. Create a section for the User Manual content and return to this page to select it.

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -1,7 +1,7 @@
 {# @var craft \craft\web\twig\variables\CraftVariable #}
 {#
 /**
- * usermanual plugin for Craft CMS 3.x
+ * usermanual plugin for Craft CMS 4.x / 5.x
  *
  * usermanual Settings.twig
  *

--- a/src/translations/en/usermanual.php
+++ b/src/translations/en/usermanual.php
@@ -18,4 +18,8 @@
  */
 return [
     'usermanual plugin loaded' => 'usermanual plugin loaded',
+    'no section error' => 'There is no section selected for the User Manual plugin. Please check the settings page.',
+    'no section error for config file' => 'There is no valid section set for the User Manual plugin. Please check the config file.',
+    'no entry error' => 'There is no entry in the selected section for the User Manual plugin. Please check the settings page. Entries must be enabled and have a slug to be displayed.',
+    'config file section error' => 'Section must be either an integer or a string.',
 ];

--- a/src/translations/en/usermanual.php
+++ b/src/translations/en/usermanual.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * usermanual plugin for Craft CMS 3.x
+ * usermanual plugin for Craft CMS 4.x / 5.x
  *
  * Craft User Manual allows developers (or even content editors) to provide CMS
  * documentation using Craft's built-in sections (singles, channels, or structures)

--- a/src/twigextensions/UserManualTwigExtension.php
+++ b/src/twigextensions/UserManualTwigExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * usermanual plugin for Craft CMS 3.x
+ * usermanual plugin for Craft CMS 4.x / 5.x
  *
  * Craft User Manual allows developers (or even content editors) to provide CMS
  * documentation using Craft's built-in sections (singles, channels, or structures)

--- a/src/twigextensions/UserManualTwigExtension.php
+++ b/src/twigextensions/UserManualTwigExtension.php
@@ -90,12 +90,16 @@ class UserManualTwigExtension extends AbstractExtension
 
         // If the app does not have a section selected, return an error message to let the admin know
         if (!$sectionId) {
-            return 'There is no section selected for the User Manual plugin. Please check the settings page.';
+            // check if the user is using a config file
+            if (Craft::$app->config->getConfigFromFile('usermanual')) {
+                return Craft::t('usermanual', 'no section error for config file');
+            }
+            return Craft::t('usermanual', 'no section error');
         }
 
         // If there are no entries in the selected section, return an error message to let the admin know
         if (!$entry) {
-            return 'There are no entries in the selected section for the User Manual Plugin. Entries must be enabled and have a slug to be displayed.';
+            return Craft::t('usermanual', 'no entry error');
         } else {
             if ($settings->templateOverride) {
                 // Setting the mode also sets the templatepath to the default for that mode

--- a/src/variables/UserManualVariable.php
+++ b/src/variables/UserManualVariable.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * usermanual plugin for Craft CMS 4.x
+ * usermanual plugin for Craft CMS 4.x / 5.x
  *
  * Craft User Manual allows developers (or even content editors) to provide CMS
  * documentation using Craft's built-in sections (singles, channels, or structures)


### PR DESCRIPTION
During a site update from Craft 4 to Craft 5, the migration process threw an error related to adding a new column to the section table. A Craft support ticket suggested uninstalling the User Manual, completing the upgrade, and then reinstalling the plugin. That fixed the issue, but I wanted to get the migration working without needing to remove _User Manual_ and re-adding it after the migration was finished.

This pull request attempts to fix that problem by restricting the `section` selection to an integer.

This update also adds a GUI for the `enableSidebar` setting which was previously only available when using a `config/usermanual.php` file.