### PR TITLE
Removed URL requirement

### DIFF
--- a/src/UserManual.php
+++ b/src/UserManual.php
@@ -13,21 +13,21 @@
 
 namespace roberskine\usermanual;
 
-use roberskine\usermanual\variables\UserManualVariable;
-use roberskine\usermanual\twigextensions\UserManualTwigExtension;
-use roberskine\usermanual\models\Settings;
-
 use Craft;
+use yii\base\Event;
 use craft\base\Model;
+
 use craft\base\Plugin;
+use craft\web\UrlManager;
 use craft\services\Plugins;
+use craft\helpers\UrlHelper;
 use craft\events\PluginEvent;
 use craft\events\RegisterUrlRulesEvent;
-use craft\helpers\UrlHelper;
+use roberskine\usermanual\models\Settings;
 use craft\web\twig\variables\CraftVariable;
-use craft\web\UrlManager;
+use roberskine\usermanual\variables\UserManualVariable;
 
-use yii\base\Event;
+use roberskine\usermanual\twigextensions\UserManualTwigExtension;
 
 /**
  * Class Usermanual
@@ -115,7 +115,7 @@ class UserManual extends Plugin
     public function getName(): string
     {
         $pluginName = Craft::t('usermanual', 'User Manual');
-        $pluginNameOverride = $this->getSettings()->pluginNameOverride;
+        $pluginNameOverride = Craft::t('usermanual', $this->getSettings()->pluginNameOverride);
 
         return ($pluginNameOverride)
             ?: $pluginName;
@@ -217,16 +217,6 @@ class UserManual extends Plugin
 
         foreach ($sections as $section) {
             $siteSettings = $this->getSectionSiteSettings($section['id']);
-            $hasUrls = false;
-            foreach ($siteSettings as $siteSetting) {
-                if ($siteSetting->hasUrls) {
-                    $hasUrls = true;
-                }
-            }
-
-            if (!$hasUrls) {
-                continue;
-            }
             $options[] = [
                 'label' => $section['name'],
                 'value' => $section['id'],
@@ -277,5 +267,4 @@ class UserManual extends Plugin
 
         return Craft::$app->entries->getSectionSiteSettings($sectionId);
     }
-
 }

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -21,10 +21,10 @@
       {% set help = craft.entries.sectionId(sectionSelected).all() %}
       <ul class="craft-{{ craftMajorVersion() }}">
         {% nav page in help %}
-          {% set active = page.slug == craft.app.request.segments|last or loop.first and craft.app.request.segments|last == 'usermanual' %}
+          {% set active = page.id == craft.app.request.segments|last or loop.first and craft.app.request.segments|last == 'usermanual' %}
           <li id="{{ page.id }}">
             <a {% if active %}class="sel"{% endif %}
-              href="{{ url('usermanual/' ~ page.uri) }}#{{ page.id }}">
+              href="{{ url('usermanual/' ~ page.id) }}">
               {{page.title}}
             </a>
             {% ifchildren %}

--- a/src/translations/es/usermanual.php
+++ b/src/translations/es/usermanual.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * usermanual plugin for Craft CMS 4.x / 5.x
+ *
+ * Craft User Manual allows developers (or even content editors) to provide CMS
+ * documentation using Craft's built-in sections (singles, channels, or structures)
+ * to create a `User Manual` or `Help` section directly in the control panel.
+ *
+ * @link      https://twitter.com/erskinerob
+ * @copyright Copyright (c) 2018 Rob Erskine
+ */
+
+/**
+ * @author    Rob Erskine
+ * @package   Usermanual
+ * @since     2.0.0
+ */
+return [
+    'User Manual' => 'Manual del usuario',
+    'usermanual plugin loaded' => 'Manual cargado',
+    'no section error' => 'No hay ninguna sección seleccionada para el plugin. Por favor visita la página de configuración',
+    'no section error for config file' => 'No hay ninguna sección válifa para el plugin. Por favor revisa el archivo de configuración',
+    'no entry error' => 'No hay entradas en la sección seleccionada para el plguin. Por favor revisa la página de configuraciones. Las entradas deben tener slug para poder mostrarse.',
+    'config file section error' => 'La sección debe ser un string o un integer.',
+];

--- a/src/twigextensions/UserManualTwigExtension.php
+++ b/src/twigextensions/UserManualTwigExtension.php
@@ -13,18 +13,18 @@
 
 namespace roberskine\usermanual\twigextensions;
 
-use roberskine\usermanual\UserManual;
-
 use Craft;
-use craft\elements\Entry;
-use craft\helpers\UrlHelper;
+
 use craft\web\View;
-use Twig\Error\LoaderError;
-use Twig\Error\RuntimeError;
-use Twig\Error\SyntaxError;
-use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 use yii\base\Exception;
+use craft\elements\Entry;
+use Twig\Error\LoaderError;
+use Twig\Error\SyntaxError;
+use craft\helpers\UrlHelper;
+use Twig\Error\RuntimeError;
+use roberskine\usermanual\UserManual;
+use Twig\Extension\AbstractExtension;
 
 
 /**
@@ -75,14 +75,14 @@ class UserManualTwigExtension extends AbstractExtension
         $sectionId = $settings->section;
 
         if (count($segments) === 1 && $segment === 'usermanual') {
-            $slug = null;
+            $id = null;
         } else {
-            $slug = $segment;
+            $id = $segment;
         }
 
         $criteria = [
             'sectionId' => $sectionId,
-            'slug' => $slug,
+            'id' => $id,
         ];
 
         Craft::configure($query, $criteria);


### PR DESCRIPTION
- Took the logic from https://github.com/RobErskine/Craft-User-Manual/compare/main...madebyraygun:Craft-User-Manual:15-remove-url-requirement and put it in the plugin's v5.
- Made the title Translatable.
- Added Spanish translation file