### PR TITLE
Two fixes: Default initial entry fix for Structure sections + show developer hint when entry is missing body field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## dev-main - 2025-06-04
 - Fixed issue where date created dictated the default entry displayed when user clicked into the User Manual. Previously, the default entry was the entry with the oldest creation date. Now, if the user manual section is defined as a structure, the order as selected in the structure will dictate the initial item displayed.
 - Fixed the logic in the default template to display the help message to the developer when the user manual entry did not contain a field with the handle `body`.
+- Added support for custom `cpTrigger`.
 
 ## 5.0.4 - 2025-02-05
 - Adding in ability to add a custom URL segment to the user manual documentation section.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft User Manual
 
+## dev-main - 2025-06-04
+- Fixed issue where date created dictated the default entry displayed when user clicked into the User Manual. Previously, the default entry was the entry with the oldest creation date. Now, if the user manual section is defined as a structure, the order as selected in the structure will dictate the initial item displayed.
+- Fixed the logic in the default template to display the help message to the developer when the user manual entry did not contain a field with the handle `body`.
+
 ## 5.0.4 - 2025-02-05
 - Adding in ability to add a custom URL segment to the user manual documentation section.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "hillholliday/craft-user-manual",
     "description": "Craft User Manual allows developers (or even content editors) to provide CMS documentation using Craft's built-in sections (singles, channels, or structures) to create a `User Manual` or `Help` section directly in the control panel.",
     "type": "craft-plugin",
-    "version": "5.0.4",
+    "version": "dev-main",
     "keywords": [
         "craft",
         "cms",

--- a/src/UserManual.php
+++ b/src/UserManual.php
@@ -112,7 +112,11 @@ class UserManual extends Plugin
     public function getCpNavItem(): ?array
     {
         $item = parent::getCpNavItem();
-        $item['url'] = '/admin/' . $this->getSettings()->urlSegment;
+
+        // get the cpTrigger from the config
+        $cpTrigger = Craft::$app->getConfig()->getGeneral()->cpTrigger;
+
+        $item['url'] =  $cpTrigger . '/' . $this->getSettings()->urlSegment;
         return $item;
     }
 

--- a/src/templates/_body.twig
+++ b/src/templates/_body.twig
@@ -1,12 +1,16 @@
 {# Using bracket notation for an accurate test, due to
    a Twig bug: http://craftcms.stackexchange.com/questions/2116/twig-is-defined-always-returning-true/2117#2117 #}
 
-{% if entry['body'] is defined %}
-    {{ entry.body }}
+{% if entry.body %}
+	{{ entry.body }}
 {% else %}
-    <p>
-        <a href="{{ url('settings/fields/new') }}">Create a field</a> with the handle of <code>body</code>
-        <b>or</b>
-        use the <a href="{{ url('settings/plugins/usermanual#settings-templateOverride-field') }}">Template Override</a> option to define your own fields.
-    </p>
+	<p>
+		<a href="{{ url('settings/fields/new') }}">Create a field</a>
+		with the handle of
+		<code>body</code>
+		<b>or</b>
+		use the
+		<a href="{{ url('settings/plugins/usermanual#settings-templateOverride-field') }}">Template Override</a>
+		option to define your own fields.
+	</p>
 {% endif %}

--- a/src/twigextensions/UserManualTwigExtension.php
+++ b/src/twigextensions/UserManualTwigExtension.php
@@ -79,8 +79,7 @@ class UserManualTwigExtension extends AbstractExtension
             // Get the first entry in the section when viewing the base URL
             $criteria = [
                 'sectionId' => $sectionId,
-                'limit' => 1,
-                'orderBy' => 'dateCreated ASC'
+                'limit' => 1
             ];
         } else {
             $criteria = [


### PR DESCRIPTION
This merge request introduces two updates to the Craft User Manual plugin:

1. Default Entry Selection Respects Structure Order
* Previously, when a section was defined as a Structure, the “default” manual entry was chosen based on creation date. As a result, the oldest entry appeared even if it wasn’t intended to be first.
* The removal of the `'orderBy' => 'dateCreated ASC'` allows the default entry to show the expected entry when the section is a Structure. If the section is not a Structure, it falls back to newest by creation date. (Previously, it was oldest by creation date.)
2.	Fix Developer Helper Notification in Default Template
* In the default template for rendering manual content, a conditional block was preventing the developer helper notification from appearing.
* That conditional has been corrected so that the helper notification (as previously defined in the template) now displays as intended.

TLDR:

* The manual opens on the entry specified by the Structure rather than arbitrary creation date.
* Developers see the helper notification without having to modify the template manually.

FYI: I've added notes in the `CHANGELOG.md` for these updates, but the actual version number will need to be updated if you accept these changes.