### PR TITLE
Markdown → CP sync (integrates #55 by @dgaidula)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes for Craft User Manual
 
 ## 5.1.0 - 2026-06-27
+- Added one-way markdown → CP sync: a `usermanual/sync` console command (with `--dry-run`) that imports a `managedFolder` of version-controlled `.md` files into the manual section, plus optional read-only enforcement of synced pages (`readOnlyManaged`) and a configurable `bodyField`. Thanks to [Dan Gaidula](https://github.com/dgaidula). ([PR #55](https://github.com/RobErskine/Craft-User-Manual/pull/55))
 - Fixed the default User Manual entry for Structure sections: the base URL now shows the first entry in structure order, rather than the oldest by creation date. Thanks to [John Morton](https://github.com/johnfmorton). ([PR #52](https://github.com/RobErskine/Craft-User-Manual/pull/52))
 - Fixed the control panel nav link on sites with a custom `cpTrigger` (it no longer hardcodes `/admin/`). Based on [John Morton](https://github.com/johnfmorton)'s report in [PR #52](https://github.com/RobErskine/Craft-User-Manual/pull/52).
 - Fixed the missing-`body`-field help message so it renders correctly under Twig `strict_variables` (dev mode) instead of throwing. Based on [John Morton](https://github.com/johnfmorton)'s change in [PR #52](https://github.com/RobErskine/Craft-User-Manual/pull/52).

--- a/README.md
+++ b/README.md
@@ -74,6 +74,60 @@ Enables the sidebar on the manual page
 
 Defaults to true.
 
+<a id="config-settings-managedFolder"></a>
+### managedFolder
+_(since 5.1.0)_ Filesystem path to a folder of `.md` files that the `usermanual/sync` command imports into the section. Alias-aware (e.g. `'@root/help-manual'`). Leave `null` to disable the sync. See [Markdown sync](#markdown-sync-git--cp) below.
+
+<a id="config-settings-readOnlyManaged"></a>
+### readOnlyManaged
+_(since 5.1.0)_ When `true`, section entries that are backed by a markdown file in `managedFolder` become **read-only in the CP** — the markdown is the source of truth. Entries with no backing file stay editable. The sync command bypasses this guard while it runs. Defaults to `false`.
+
+<a id="config-settings-bodyField"></a>
+### bodyField
+_(since 5.1.0)_ Handle of the field that stores the markdown body on the section's entries. Defaults to `body`. Set this when you use a `templateOverride` that reads a different field (e.g. `helpContent`).
+
+## Markdown sync (git → CP)
+
+_(since 5.1.0)_ Instead of (or in addition to) editing manual pages in the control panel, you can keep them as version-controlled markdown and push them into the CP with a console command. This keeps documentation diffable, reviewable, and easy to maintain across multiple sites.
+
+1. Point `managedFolder` at a folder of `.md` files (in `config/usermanual.php`):
+
+   ```php
+   return [
+       'section'         => 'secHelp',        // your manual section
+       'managedFolder'   => '@root/help-manual',
+       'bodyField'       => 'helpContent',    // if not the default `body`
+       'readOnlyManaged' => true,             // optional: lock CP editing of synced pages
+   ];
+   ```
+
+2. Author each page as a `.md` file with optional YAML frontmatter:
+
+   ```markdown
+   ---
+   title: Getting Started
+   slug: getting-started      # optional; defaults to the filename (minus an "NN-" order prefix)
+   parent: craft-cms          # optional; slug of the parent page (structure sections)
+   order: 10                  # optional; sort hint, used only when first creating the page
+   enabled: true              # optional; default true
+   delete: false              # optional; true soft-deletes the page with this slug
+   ---
+   # Getting Started
+
+   Markdown body…
+   ```
+
+3. Run the sync (e.g. on deploy, on cron, or by hand):
+
+   ```bash
+   craft usermanual/sync            # import managedFolder/*.md
+   craft usermanual/sync --dry-run  # report what would change, write nothing
+   ```
+
+The sync is **one-way** (git → DB) and **idempotent** — it only saves a page when its title, body, or enabled state actually changed, and it never touches section entries that have no backing file (so a CP-maintained page can live alongside the managed ones). Removals are declarative: ship a file with `delete: true` to retire an obsolete page.
+
+> **Note:** the sync writes through Craft's element API, so the target section's entry type needs an editable **Title** field — entry types that auto-generate their title (via a Title Format) won't have their titles updated by the sync.
+
 ## Some notes
 * The plugin currently only pulls in the `body` field from each entry in the selected section, unless you're using a template override.
 * While the **User Manual** section works best with `Structures`, you can certainly get away with using a one-off `Single`.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,28 @@ _(since 5.1.0)_ Instead of (or in addition to) editing manual pages in the contr
 
 The sync is **one-way** (git → DB) and **idempotent** — it only saves a page when its title, body, or enabled state actually changed, and it never touches section entries that have no backing file (so a CP-maintained page can live alongside the managed ones). Removals are declarative: ship a file with `delete: true` to retire an obsolete page.
 
+### Rendering the markdown as HTML
+
+The sync stores each file's body **verbatim** in the configured `bodyField`, and the default template prints it raw with `{{ entry.body }}`. That means markdown syntax (headings, bold, lists) and blank-line paragraph breaks are **not** converted — the browser shows them as literal text / a single run-on line.
+
+To render the markdown as HTML, point the [`templateOverride`](#config-settings-templateOverride) setting at a site template that runs the body through Craft's [`|md` filter](https://craftcms.com/docs/5.x/reference/twig/filters.html#md). Create `templates/usermanual-markdown.twig` in your project:
+
+```twig
+{% if entry.fieldValues.body ?? false %}
+    {{ entry.body | md }}
+{% else %}
+    <p>This page has no <code>body</code> content yet.</p>
+{% endif %}
+```
+
+…then set it in `config/usermanual.php`:
+
+```php
+'templateOverride' => 'usermanual-markdown',
+```
+
+> The default template is intentionally left as raw output so existing installs whose `body` field already contains rich text / HTML aren't double-processed. Opt into markdown rendering per the override above.
+
 > **Note:** the sync writes through Craft's element API, so the target section's entry type needs an editable **Title** field — entry types that auto-generate their title (via a Title Format) won't have their titles updated by the sync.
 
 ## Some notes

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "craftcms/cms": "^4.0.0|^5.0.0"
+        "craftcms/cms": "^4.0.0|^5.0.0",
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/UserManual.php
+++ b/src/UserManual.php
@@ -15,14 +15,17 @@ namespace roberskine\usermanual;
 
 use Craft;
 use yii\base\Event;
+use yii\base\ModelEvent;
 
 use craft\base\Plugin;
+use craft\elements\Entry;
 use craft\web\UrlManager;
 use craft\services\Plugins;
 use craft\helpers\UrlHelper;
 use craft\events\PluginEvent;
 use craft\events\RegisterUrlRulesEvent;
 use roberskine\usermanual\models\Settings;
+use roberskine\usermanual\services\Manual;
 use craft\web\twig\variables\CraftVariable;
 use roberskine\usermanual\variables\UserManualVariable;
 
@@ -35,6 +38,7 @@ use roberskine\usermanual\twigextensions\UserManualTwigExtension;
  * @package   Usermanual
  * @since     2.0.0
  *
+ * @property-read Manual $manual
  */
 class UserManual extends Plugin
 {
@@ -45,6 +49,14 @@ class UserManual extends Plugin
      * @var UserManual
      */
     public static UserManual $plugin;
+
+    /**
+     * True while the `usermanual/sync` command is writing entries, so the
+     * read-only guard lets the sync's own saves through.
+     *
+     * @var bool
+     */
+    public static bool $isSyncing = false;
 
     // Public Properties
     // =========================================================================
@@ -67,8 +79,22 @@ class UserManual extends Plugin
 
         $this->name = $this->getName();
 
+        // Register the manual (markdown sync) service
+        $this->setComponents([
+            'manual' => Manual::class,
+        ]);
+
+        // Use the console controller namespace for CLI requests so
+        // `craft usermanual/sync` resolves to console\controllers\SyncController.
+        if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+            $this->controllerNamespace = 'roberskine\\usermanual\\console\\controllers';
+        }
+
         // Register twig extensions
         $this->_addTwigExtensions();
+
+        // One-way sync guard: make markdown-backed pages read-only in the CP
+        $this->_registerReadOnlyGuard();
 
         // Register CP routes
         Event::on(
@@ -225,6 +251,63 @@ class UserManual extends Plugin
     private function _addTwigExtensions(): void
     {
         Craft::$app->view->registerTwigExtension(new UserManualTwigExtension);
+    }
+
+    /**
+     * The Manual (markdown sync) service.
+     */
+    public function getManual(): Manual
+    {
+        /** @var Manual $manual */
+        $manual = $this->get('manual');
+        return $manual;
+    }
+
+    /**
+     * When `readOnlyManaged` is on, block CP saves of section entries that are
+     * backed by a markdown file — the markdown is the source of truth. The sync
+     * command bypasses this (via self::$isSyncing). Entries with no backing file
+     * (e.g. a CP-maintained changelog) remain editable.
+     */
+    private function _registerReadOnlyGuard(): void
+    {
+        Event::on(
+            Entry::class,
+            Entry::EVENT_BEFORE_SAVE,
+            function (ModelEvent $event): void {
+                if (self::$isSyncing || !$this->getSettings()->readOnlyManaged) {
+                    return;
+                }
+                if (!Craft::$app->getRequest()->getIsCpRequest()) {
+                    return; // only guard interactive CP saves
+                }
+
+                /** @var Entry $entry */
+                $entry = $event->sender;
+
+                // Ignore drafts/revisions/propagation/bulk-resaves — only the
+                // canonical CP "Save" is blocked.
+                if ($entry->getIsDraft() || $entry->getIsRevision() || $entry->propagating || $entry->resaving) {
+                    return;
+                }
+                if ((int)$entry->sectionId !== (int)$this->getSettings()->section) {
+                    return;
+                }
+                if (!isset($this->getManual()->managedSlugs()[$entry->slug])) {
+                    return; // not a markdown-backed page — leave editable
+                }
+
+                $event->isValid = false;
+                $folder = $this->getSettings()->managedFolder;
+                $entry->addError(
+                    'title',
+                    Craft::t('usermanual', 'This page is managed in source control ({folder}/{slug}.md). Edit the markdown file and re-run “craft usermanual/sync” instead of editing it here.', [
+                        'folder' => $folder,
+                        'slug' => $entry->slug,
+                    ])
+                );
+            }
+        );
     }
 
     private function getSectionOptions(): array

--- a/src/config.php
+++ b/src/config.php
@@ -30,4 +30,14 @@ return [
     'templateOverride' => null,
     'section' => null, // section ID (int) or section handle (string)
     'enabledSideBar' => true,
+
+    // --- Markdown sync (since 5.1.0) ---------------------------------------
+    // Folder of `.md` files imported into the section by `craft usermanual/sync`.
+    // Alias-aware (e.g. '@root/help-manual'). Null disables the sync.
+    'managedFolder' => null,
+    // Make markdown-backed pages read-only in the CP (markdown = source of truth).
+    'readOnlyManaged' => false,
+    // Field handle that stores the markdown body on the section's entries.
+    // Defaults to 'body'; set to your field handle if you use a templateOverride.
+    'bodyField' => 'body',
 ];

--- a/src/console/controllers/SyncController.php
+++ b/src/console/controllers/SyncController.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * usermanual plugin for Craft CMS 4.x / 5.x
+ *
+ * @link      https://twitter.com/erskinerob
+ * @copyright Copyright (c) 2018 Rob Erskine
+ */
+
+namespace roberskine\usermanual\console\controllers;
+
+use craft\console\Controller;
+use craft\helpers\Console;
+use roberskine\usermanual\UserManual;
+use yii\console\ExitCode;
+
+/**
+ * Syncs a folder of markdown files into the User Manual section.
+ *
+ * Usage:
+ *   craft usermanual/sync            # import managedFolder/*.md into the section
+ *   craft usermanual/sync --dry-run  # report what would change, write nothing
+ *
+ * Configure `managedFolder` (and optionally `bodyField`) in config/usermanual.php.
+ * The sync is one-way (git → DB), idempotent, and change-detecting.
+ *
+ * @since 5.1.0
+ */
+class SyncController extends Controller
+{
+    /**
+     * @var bool Report what would change without writing anything.
+     */
+    public bool $dryRun = false;
+
+    public function options($actionID): array
+    {
+        return array_merge(parent::options($actionID), ['dryRun']);
+    }
+
+    public function optionAliases(): array
+    {
+        return array_merge(parent::optionAliases(), ['d' => 'dryRun']);
+    }
+
+    /**
+     * Import the managed markdown folder into the User Manual section.
+     */
+    public function actionIndex(): int
+    {
+        $settings = UserManual::$plugin->getSettings();
+        $this->stdout("User Manual sync" . ($this->dryRun ? " (dry run)" : "") . "\n", Console::FG_CYAN);
+        $this->stdout("  folder : {$settings->managedFolder}\n");
+        $this->stdout("  section: {$settings->section}   bodyField: {$settings->bodyField}\n\n");
+
+        $summary = UserManual::$plugin->getManual()->sync(
+            $this->dryRun,
+            fn(string $msg) => $this->stdout("  {$msg}\n", Console::FG_GREY)
+        );
+
+        $this->stdout("\n");
+        $this->stdout("  created   : {$summary['created']}\n");
+        $this->stdout("  updated   : {$summary['updated']}\n");
+        $this->stdout("  unchanged : {$summary['unchanged']}\n");
+        $this->stdout("  deleted   : {$summary['deleted']}\n");
+        $this->stdout("  skipped   : {$summary['skipped']}\n");
+
+        if (!empty($summary['errors'])) {
+            $this->stderr("\n  ERRORS:\n", Console::FG_RED);
+            foreach ($summary['errors'] as $err) {
+                $this->stderr("   - {$err}\n", Console::FG_RED);
+            }
+            return ExitCode::UNSPECIFIED_ERROR;
+        }
+
+        $this->stdout("\nDone.\n", Console::FG_GREEN);
+        return ExitCode::OK;
+    }
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -53,6 +53,39 @@ class Settings extends Model
      */
     public string $urlSegment = 'usermanual';
 
+    /**
+     * Filesystem path (alias-aware, e.g. "@root/help-manual") to a folder of
+     * `.md` files that the `usermanual/sync` console command imports into the
+     * configured section. Empty disables the sync.
+     *
+     * @var string|null
+     * @since 5.1.0
+     */
+    public ?string $managedFolder = null;
+
+    /**
+     * When true, entries in the configured section that have a backing `.md`
+     * file in `managedFolder` become read-only in the control panel — the
+     * markdown is the source of truth. Entries with no backing file (e.g. a
+     * CP-maintained changelog) stay editable. The `usermanual/sync` command
+     * bypasses this guard while it runs.
+     *
+     * @var bool
+     * @since 5.1.0
+     */
+    public bool $readOnlyManaged = false;
+
+    /**
+     * Handle of the field on the section's entries that stores the markdown
+     * body. Defaults to `body` (the plugin's default template field). Sites
+     * using a `templateOverride` with a different field (e.g. `helpContent`)
+     * set this accordingly.
+     *
+     * @var string
+     * @since 5.1.0
+     */
+    public string $bodyField = 'body';
+
     // Public Methods
     // =========================================================================
 
@@ -62,9 +95,9 @@ class Settings extends Model
     public function rules(): array
     {
         return [
-            [['pluginNameOverride', 'templateOverride', 'urlSegment'], 'string'],
+            [['pluginNameOverride', 'templateOverride', 'urlSegment', 'managedFolder', 'bodyField'], 'string'],
             ['section', 'number'],
-            ['enabledSideBar', 'boolean']
+            [['enabledSideBar', 'readOnlyManaged'], 'boolean'],
         ];
     }
 }

--- a/src/services/Manual.php
+++ b/src/services/Manual.php
@@ -1,0 +1,326 @@
+<?php
+
+/**
+ * usermanual plugin for Craft CMS 4.x / 5.x
+ *
+ * @link      https://twitter.com/erskinerob
+ * @copyright Copyright (c) 2018 Rob Erskine
+ */
+
+namespace roberskine\usermanual\services;
+
+use Craft;
+use craft\base\Component;
+use craft\elements\Entry;
+use craft\elements\User;
+use craft\helpers\StringHelper;
+use roberskine\usermanual\UserManual;
+use Symfony\Component\Yaml\Yaml;
+use Throwable;
+
+/**
+ * Manual service — imports a folder of markdown files into the configured
+ * "User Manual" section as a one-way (git → DB) sync.
+ *
+ * Each `.md` file may begin with a YAML frontmatter block:
+ *
+ *     ---
+ *     title: Getting Started
+ *     slug: getting-started      # optional; defaults to the filename (minus an "NN-" order prefix)
+ *     parent: craft-cms          # optional; slug of the parent page (structure sections only)
+ *     order: 10                  # optional; sort hint used only when creating a new page
+ *     enabled: true              # optional; default true
+ *     delete: false              # optional; when true, soft-deletes the page with this slug
+ *     ---
+ *     # Markdown body…
+ *
+ * The remainder of the file (after the frontmatter) is written verbatim into
+ * the section entry's body field (Settings::$bodyField, default `body`).
+ *
+ * The sync is idempotent and change-detecting: a page is only saved when its
+ * title, body, or enabled state actually differ from the file. Entries in the
+ * section that have NO backing file are never touched (so a CP-maintained page
+ * can coexist). Removals are declarative: a file with `delete: true`.
+ *
+ * @author    Rob Erskine
+ * @package   Usermanual
+ * @since     5.1.0
+ */
+class Manual extends Component
+{
+    /**
+     * Resolve the configured managed folder to an absolute path, or null when
+     * unset / missing.
+     */
+    public function getManagedFolderPath(): ?string
+    {
+        $folder = UserManual::$plugin->getSettings()->managedFolder;
+        if (!$folder) {
+            return null;
+        }
+        $path = Craft::getAlias($folder);
+        return is_string($path) && is_dir($path) ? rtrim($path, '/') : null;
+    }
+
+    /**
+     * Return every parsed `.md` file in the managed folder, keyed by slug.
+     *
+     * @return array<string, array> slug => parsed file
+     */
+    public function getManagedFiles(): array
+    {
+        $path = $this->getManagedFolderPath();
+        if ($path === null) {
+            return [];
+        }
+
+        $files = [];
+        foreach (glob($path . '/*.md') ?: [] as $file) {
+            $parsed = $this->parseFile($file);
+            if ($parsed !== null) {
+                $files[$parsed['slug']] = $parsed;
+            }
+        }
+        return $files;
+    }
+
+    /**
+     * The set of slugs that are backed by a managed file (excludes `delete`
+     * tombstones). Used by the read-only guard. Cached per request.
+     *
+     * @return array<string, true>
+     */
+    public function managedSlugs(): array
+    {
+        static $cache = null;
+        if ($cache !== null) {
+            return $cache;
+        }
+        $cache = [];
+        foreach ($this->getManagedFiles() as $slug => $file) {
+            if (empty($file['delete'])) {
+                $cache[$slug] = true;
+            }
+        }
+        return $cache;
+    }
+
+    /**
+     * Parse a single markdown file into its frontmatter + body. Returns null
+     * if the file can't be read.
+     *
+     * @return array{slug:string,title:?string,parent:?string,order:int,enabled:bool,delete:bool,body:string}|null
+     */
+    public function parseFile(string $file): ?array
+    {
+        $raw = @file_get_contents($file);
+        if ($raw === false) {
+            return null;
+        }
+        $raw = preg_replace('/^\xEF\xBB\xBF/', '', $raw); // strip UTF-8 BOM
+
+        $front = [];
+        $body = $raw;
+        // Frontmatter: a leading "---" line, YAML, then a closing "---" line.
+        if (preg_match('/^---\s*\R(.*?)\R---\s*\R?(.*)$/s', $raw, $m)) {
+            try {
+                $front = Yaml::parse($m[1]) ?: [];
+            } catch (Throwable) {
+                $front = [];
+            }
+            $body = $m[2];
+        }
+
+        $base = preg_replace('/\.md$/i', '', basename($file));
+        $slug = (string)($front['slug'] ?? preg_replace('/^\d+[-_]/', '', $base));
+        $slug = StringHelper::slugify($slug);
+
+        return [
+            'slug' => $slug,
+            'title' => isset($front['title']) ? (string)$front['title'] : null,
+            'parent' => isset($front['parent']) ? StringHelper::slugify((string)$front['parent']) : null,
+            'order' => (int)($front['order'] ?? 0),
+            'enabled' => (bool)($front['enabled'] ?? true),
+            'delete' => (bool)($front['delete'] ?? false),
+            'body' => $this->normalizeBody($body),
+        ];
+    }
+
+    /**
+     * Normalize a markdown body so re-syncs are idempotent: LF line endings, no
+     * leading blank lines (left by the frontmatter block), and no trailing
+     * whitespace — matching how Craft stores a PlainText value.
+     */
+    private function normalizeBody(string $body): string
+    {
+        $body = str_replace(["\r\n", "\r"], "\n", $body);
+        return rtrim(ltrim($body, "\n"));
+    }
+
+    /**
+     * Run the sync. Returns a summary array of counts + any errors.
+     *
+     * @param bool $dryRun when true, report what would change without saving
+     * @param callable|null $log optional line logger (string $msg) => void
+     * @return array{created:int,updated:int,unchanged:int,deleted:int,skipped:int,errors:string[]}
+     */
+    public function sync(bool $dryRun = false, ?callable $log = null): array
+    {
+        $log ??= static fn(string $m) => null;
+        $summary = ['created' => 0, 'updated' => 0, 'unchanged' => 0, 'deleted' => 0, 'skipped' => 0, 'errors' => []];
+
+        $settings = UserManual::$plugin->getSettings();
+        $sectionId = (int)$settings->section;
+        $bodyField = $settings->bodyField ?: 'body';
+
+        $path = $this->getManagedFolderPath();
+        if ($path === null) {
+            $summary['errors'][] = "managedFolder is not set or does not exist: {$settings->managedFolder}";
+            return $summary;
+        }
+        if (!$sectionId) {
+            $summary['errors'][] = 'No section configured for the User Manual plugin.';
+            return $summary;
+        }
+
+        // Craft 5 merged section management into the Entries service; Craft 4
+        // still exposes it on the Sections service. Branch so the sync works on
+        // both (matching the version branching elsewhere in the plugin).
+        $isCraft5 = version_compare(Craft::$app->getVersion(), '5.0.0', '>=');
+        $section = $isCraft5
+            ? Craft::$app->entries->getSectionById($sectionId)
+            : Craft::$app->sections->getSectionById($sectionId);
+        if ($section === null) {
+            $summary['errors'][] = "Configured section {$sectionId} not found.";
+            return $summary;
+        }
+        $entryType = $section->getEntryTypes()[0] ?? null;
+        if ($entryType === null) {
+            $summary['errors'][] = "Section {$section->handle} has no entry types.";
+            return $summary;
+        }
+        $structureId = $section->structureId ?? null;
+        $siteId = Craft::$app->getSites()->getPrimarySite()->id;
+        $authorId = User::find()->admin(true)->status(null)->one()?->id;
+
+        $files = $this->getManagedFiles();
+        if (!$files) {
+            $log("No .md files found in {$path}");
+            return $summary;
+        }
+
+        // Process creates/updates/deletes (sorted: deletes last, then by order).
+        uasort($files, static fn($a, $b) => [$a['delete'], $a['order']] <=> [$b['delete'], $b['order']]);
+
+        UserManual::$isSyncing = true;
+        try {
+            foreach ($files as $slug => $file) {
+                $existing = Entry::find()->sectionId($sectionId)->slug($slug)->status(null)->one();
+
+                // --- Tombstone: delete if present -------------------------------
+                if ($file['delete']) {
+                    if ($existing === null) {
+                        $summary['skipped']++;
+                        continue;
+                    }
+                    if ($dryRun) {
+                        $log("DELETE  {$slug}");
+                        $summary['deleted']++;
+                        continue;
+                    }
+                    if (Craft::$app->getElements()->deleteElement($existing)) {
+                        $log("deleted {$slug}");
+                        $summary['deleted']++;
+                    } else {
+                        $summary['errors'][] = "delete failed for {$slug}: " . implode('; ', $existing->getFirstErrors());
+                    }
+                    continue;
+                }
+
+                $title = $file['title'] ?? StringHelper::titleize(str_replace('-', ' ', $slug));
+                $body = $file['body'];
+
+                // --- Update in place --------------------------------------------
+                if ($existing !== null) {
+                    $curBody = $this->normalizeBody((string)$existing->getFieldValue($bodyField));
+                    $changed = $existing->title !== $title
+                        || $curBody !== $body
+                        || $existing->enabled !== $file['enabled'];
+                    if (!$changed) {
+                        $summary['unchanged']++;
+                        continue;
+                    }
+                    if ($dryRun) {
+                        $log("UPDATE  {$slug}");
+                        $summary['updated']++;
+                        continue;
+                    }
+                    $existing->title = $title;
+                    $existing->enabled = $file['enabled'];
+                    $existing->setFieldValue($bodyField, $body);
+                    if (Craft::$app->getElements()->saveElement($existing)) {
+                        $log("updated {$slug}");
+                        $summary['updated']++;
+                    } else {
+                        $summary['errors'][] = "save failed for {$slug}: " . implode('; ', $existing->getFirstErrors());
+                    }
+                    continue;
+                }
+
+                // --- Create -----------------------------------------------------
+                if ($dryRun) {
+                    $log("CREATE  {$slug}");
+                    $summary['created']++;
+                    continue;
+                }
+                $entry = new Entry();
+                $entry->sectionId = $sectionId;
+                $entry->typeId = $entryType->id;
+                $entry->siteId = $siteId;
+                $entry->slug = $slug;
+                $entry->title = $title;
+                $entry->enabled = $file['enabled'];
+                if ($authorId) {
+                    // Craft 5 supports multiple authors via setAuthorId();
+                    // Craft 4 uses the single authorId property.
+                    if ($isCraft5) {
+                        $entry->setAuthorId($authorId);
+                    } else {
+                        $entry->authorId = $authorId;
+                    }
+                }
+                $entry->setFieldValue($bodyField, $body);
+                if (Craft::$app->getElements()->saveElement($entry)) {
+                    $log("created {$slug}");
+                    $summary['created']++;
+                } else {
+                    $summary['errors'][] = "create failed for {$slug}: " . implode('; ', $entry->getFirstErrors());
+                }
+            }
+
+            // Second pass: parent placement (structure sections only), once all
+            // pages exist so parents are resolvable.
+            if ($structureId && !$dryRun) {
+                foreach ($files as $slug => $file) {
+                    if ($file['delete'] || !$file['parent']) {
+                        continue;
+                    }
+                    $entry = Entry::find()->sectionId($sectionId)->slug($slug)->status(null)->one();
+                    $parent = Entry::find()->sectionId($sectionId)->slug($file['parent'])->status(null)->one();
+                    if (!$entry || !$parent) {
+                        continue;
+                    }
+                    if ($entry->getParent()?->id === $parent->id) {
+                        continue; // already correctly nested
+                    }
+                    Craft::$app->getStructures()->append($structureId, $entry, $parent);
+                    $log("nested  {$slug} under {$file['parent']}");
+                }
+            }
+        } finally {
+            UserManual::$isSyncing = false;
+        }
+
+        return $summary;
+    }
+}


### PR DESCRIPTION
Integrates the markdown → CP sync feature from #55 (by @dgaidula), rebased onto current `main` with the corrections found in review and live testing. Dan is credited as co-author on the commit.

## What it adds
A `craft usermanual/sync` console command (with `--dry-run`) that imports a `managedFolder` of version-controlled `.md` files into the manual section — plus optional read-only enforcement of synced pages (`readOnlyManaged`) and a configurable `bodyField`. See the new README section for usage.

## Corrections vs. #55
- **Declared `symfony/yaml`** in `require` (the service imports it directly; it was only present transitively via Craft).
- **Dropped the re-added `composer.json` `"version"` field** — `main` is tag-driven.
- **Branched the Craft-5-only APIs** in `Manual::sync()` (`getSectionById`, author assignment) by version, so the command doesn't fatal on Craft 4 — matching the plugin's existing version branching.
- Rebased onto `main` so it keeps `getSettings(): ?Settings`, the cpTrigger nav fix, and the `_body.twig` strict-variables fix (all from the 5.1.0 work).

## Verified live (Craft 5, DDEV)
- ✅ Create from markdown, dry-run accuracy
- ✅ Structure nesting (`parent:` frontmatter)
- ✅ Delete tombstones (`delete: true`); unmanaged entries untouched
- ✅ **Idempotency** — re-runs are true no-ops (`unchanged`) on a section with a title field
- ✅ **Read-only guard** — a CP save of a managed page is blocked ("managed in source control") and the entry is left unchanged
- ✅ PHPStan clean across the matrix

Supersedes #55.
